### PR TITLE
Add support for japanese file, Add label config

### DIFF
--- a/cvt.ini
+++ b/cvt.ini
@@ -13,6 +13,9 @@
 # * It is useful for extending and experimenting with Cvt
 # * If you have generally useful measurements to add - let me know on Cvt's github
 
+# The display name of the default item
+# Default: "Cvt: "
+#item_label = "Cvt: "
 
 [var]
 # As in every Keypirinha's configuration file, you may optionally include a


### PR DESCRIPTION
Hi, thanks for useful package.
I added two features.

## 1. Support for japanese cvtdefs.json file.

In japanese windows, python's open function load japanese text file as s-jis encoding by default.
So can't load japanese utf-8 file like this.

```
{
    "name": "Era",
    "desc": "Convert units of calendar era",
    "units": [
        {"name": "西暦", "factor": "1", "aliases": ["AD", "CE"], "offset": "0"},
        {"name": "明治", "factor": "1", "aliases": ["Meiji", "gM"], "offset": "0-1867"},
        {"name": "大正", "factor": "1", "aliases": ["Taisho", "gT"], "offset": "0-1911"},
        {"name": "昭和", "factor": "1", "aliases": ["Showa", "gS"], "offset": "0-1925"},
        {"name": "平成", "factor": "1", "aliases": ["Heisei", "gH"], "offset": "0-1988"},
        {"name": "令和", "factor": "1", "aliases": ["Reiwa", "gR"], "offset": "0-2018"}
    ]
}
```

c.f. https://en.wikipedia.org/wiki/Japanese_units_of_measurement
c.f. https://en.wikipedia.org/wiki/Regnal_year

## 2. Item label config in ini file.

```
[main]
item_label = "Cvt: "
```